### PR TITLE
fix: Remove "No newline" from previews

### DIFF
--- a/lib/pull-request/get-new-tweets.js
+++ b/lib/pull-request/get-new-tweets.js
@@ -45,7 +45,10 @@ async function getNewTweets({ octokit, toolkit, payload }) {
   const newTweets = parseDiff(data)
     .filter((file) => file.new && /^tweets\/.*\.tweet$/.test(file.to))
     .map((file) =>
-      file.chunks[0].changes.map((line) => line.content.substr(1)).join("\n")
+      file.chunks[0].changes
+        .filter((line) => line.content.startsWith("+")) // ignore No newline at EOF
+        .map((line) => line.content.substr(1))
+        .join("\n")
     );
 
   toolkit.info(`New tweets found: ${newTweets.length}`);

--- a/test/pull-request-has-tweet-no-newline/event.json
+++ b/test/pull-request-has-tweet-no-newline/event.json
@@ -1,0 +1,22 @@
+{
+  "action": "opened",
+  "pull_request": {
+    "number": 123,
+    "base": {
+      "ref": "main"
+    },
+    "head": {
+      "sha": "0000000000000000000000000000000000000002",
+      "repo": {
+        "fork": false
+      }
+    }
+  },
+  "repository": {
+    "default_branch": "main",
+    "name": "action",
+    "owner": {
+      "login": "twitter-together"
+    }
+  }
+}

--- a/test/pull-request-has-tweet-no-newline/test.js
+++ b/test/pull-request-has-tweet-no-newline/test.js
@@ -1,0 +1,80 @@
+/**
+ * This test checks the happy path of pull request adding a new *.tweet file
+ */
+
+const nock = require("nock");
+const tap = require("tap");
+
+// SETUP
+process.env.GITHUB_EVENT_NAME = "pull_request";
+process.env.GITHUB_TOKEN = "secret123";
+process.env.GITHUB_EVENT_PATH = require.resolve("./event.json");
+
+// set other env variables so action-toolkit is happy
+process.env.GITHUB_REF = "";
+process.env.GITHUB_WORKSPACE = "";
+process.env.GITHUB_WORKFLOW = "";
+process.env.GITHUB_ACTION = "twitter-together";
+process.env.GITHUB_ACTOR = "";
+process.env.GITHUB_REPOSITORY = "";
+process.env.GITHUB_SHA = "";
+
+// MOCK
+nock("https://api.github.com", {
+  reqheaders: {
+    authorization: "token secret123",
+  },
+})
+  // get changed files
+  .get("/repos/twitter-together/action/pulls/123/files")
+  .reply(200, [
+    {
+      status: "added",
+      filename: "tweets/hello-world.tweet",
+    },
+  ]);
+
+// get pull request diff
+nock("https://api.github.com", {
+  reqheaders: {
+    accept: "application/vnd.github.diff",
+    authorization: "token secret123",
+  },
+})
+  .get("/repos/twitter-together/action/pulls/123")
+  .reply(
+    200,
+    `diff --git a/tweets/hello-world.tweet b/tweets/hello-world.tweet
+new file mode 100644
+index 0000000..0123456
+--- /dev/null
++++ b/tweets/hello-world.tweet
+@@ -0,0 +1 @@
++Hello, world!
+\\ No newline at end of file
+`
+  );
+
+// create check run
+nock("https://api.github.com")
+  // get changed files
+  .post("/repos/twitter-together/action/check-runs", (body) => {
+    tap.equal(body.name, "preview");
+    tap.equal(body.head_sha, "0000000000000000000000000000000000000002");
+    tap.equal(body.status, "completed");
+    tap.equal(body.conclusion, "success");
+    tap.same(body.output, {
+      title: "1 tweet(s)",
+      summary: "### ✅ Valid\n\n> Hello, world!",
+    });
+
+    return true;
+  })
+  .reply(201);
+
+process.on("exit", (code) => {
+  tap.equal(code, 0);
+  tap.same(nock.pendingMocks(), []);
+});
+
+require("../../lib");


### PR DESCRIPTION
This PR is a fix for #217 and possibly address https://github.com/twitter-together/action/issues/153#issuecomment-1014122152. 

When generating the preview, the `parse-diff` library is used to get the contents of new tweets, but was including `\\ No newline at end of file` for new `.tweet` files that are affected.
 
This PR filters out lines in the diff that do not start with `+`, ensuring that only additional lines are actually included in the text of the parsed tweet. 

Perhaps there is a better approach to fixing than this PR, but the [parse-diff](https://github.com/sergeyt/parse-diff) library does not provide many options. If the diff passed to `parseDiff` is fully escaped (i.e. `\\\\ No newline at end of file`), the library does remove this line from the list of additional lines.

I have included a test case that uses the diff output from a sample run of of a newline tweet: https://github.com/IstoraMandiri/twitter-together-testing/actions/runs/3172702318/jobs/5167466385#step:2:8

Preview before this PR https://github.com/IstoraMandiri/twitter-together-testing/runs/8672961177

Preview after this PR https://github.com/IstoraMandiri/twitter-together-testing/runs/8672999162