### PR TITLE
feat: Add tweet preview and tweeted URL to PR conversation

### DIFF
--- a/lib/pull-request/create-check-run.js
+++ b/lib/pull-request/create-check-run.js
@@ -38,7 +38,9 @@ async function createCheckRun(
     process.exit(allTweetsValid ? 0 : 1);
   }
 
-  const summary = parsedTweets.map(tweetToCheckRunSummary).join("\n\n---\n\n");
+  const summary = parsedTweets
+    .map((tweet) => tweetToCheckRunSummary(tweet))
+    .join("\n\n---\n\n");
 
   const response = await octokit.request(
     "POST /repos/:owner/:repo/check-runs",

--- a/lib/pull-request/create-check-run.js
+++ b/lib/pull-request/create-check-run.js
@@ -38,6 +38,8 @@ async function createCheckRun(
     process.exit(allTweetsValid ? 0 : 1);
   }
 
+  const summary = parsedTweets.map(tweetToCheckRunSummary).join("\n\n---\n\n");
+
   const response = await octokit.request(
     "POST /repos/:owner/:repo/check-runs",
     {
@@ -54,12 +56,20 @@ async function createCheckRun(
       conclusion: allTweetsValid ? "success" : "failure",
       output: {
         title: `${parsedTweets.length} tweet(s)`,
-        summary: parsedTweets.map(tweetToCheckRunSummary).join("\n\n---\n\n"),
+        summary,
       },
     }
   );
 
   toolkit.info(`check run created: ${response.data.html_url}`);
+
+  // post preview to the PR conversation
+  await octokit.rest.issues.createComment({
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    issue_number: payload.pull_request.number,
+    body: `## Added ${parsedTweets.length} tweet(s)\n\n${summary}`,
+  });
 }
 
 function tweetToCheckRunSummary(tweet) {


### PR DESCRIPTION
Fixes #223 

After each PR preview generation, the bot will post a comment to the PR thread, making things far more obvious for contributors and maintainers.

Example: https://github.com/IstoraMandiri/twitter-together-testing/pull/18

EDIT: In draft mode until I implement post-merge URL tweeting and remote fork PRs.

TODO: Document updating workflow, gituhb for "Actions permissions", splitting workflow into two files