### PR TITLE
fix: run build before git commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GR2M_PAT_FOR_SEMANTIC_RELEASE }}
-      - run: npm run build
       - run: >-
           git push --force
           https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
         }
       ],
       [
+        "@semantic-release/exec", 
+        {
+          "publishCmd": "npm run build"
+        }
+      ],
+      [
         "@semantic-release/git",
         {
           "assets": [

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         }
       ],
       [
-        "@semantic-release/exec", 
+        "@semantic-release/exec",
         {
           "publishCmd": "npm run build"
         }


### PR DESCRIPTION
This PR moves an `npm run build` step out of GitHub actions and into the semantic release workflow in this repo.

The advantage of this would be to trigger an NPM build immediately before build contents are committed to the repo, vs the current practice of committing then building (currently, the distributed/compiled file is not committed automatically, hence this change).