### PR TITLE
fix: add semantic release exec plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
-      - run: npm install --save-dev @semantic-release/git
+      - run: npm install --save-dev @semantic-release/git @semantic-release/exec
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GR2M_PAT_FOR_SEMANTIC_RELEASE }}


### PR DESCRIPTION
When I filed PR #232, I only modified the semantic release configuration without properly installing plugins. This causes CI to fail.

This follow up PR includes the correct plugin so CI passes going forward.